### PR TITLE
Add XBOX Series X controller config + fix segmentation fault

### DIFF
--- a/get_controller_config.c
+++ b/get_controller_config.c
@@ -39,12 +39,18 @@ int main(int argc, char** argv)
     struct SDL_GUID guid = SDL_GetJoystickGUID(joystick);
     char buf[33];
     SDL_GUIDToString(guid, buf, 33);
-    printf("\033[34mJoystick %zu: %s\033[0m\n", i, name);
-
+    
     /*
-     * For SDL2 compatibility, CRC bytes must be zeroed out.
-     */
+    * For SDL2 compatibility, CRC bytes must be zeroed out.
+    */
     char* mapping = SDL_GetGamepadMappingForGUID(guid);
+    if (!mapping) 
+    {
+      printf("Joystick %zu (%s) could not be mapped: %s. Continuing", i, name, SDL_GetError());
+      continue; // Not a gamepad
+    }
+    
+    printf("\033[34mJoystick %zu: %s\033[0m\n", i, name);
     for (size_t guid_byte = 2; guid_byte < 4; guid_byte++)
     {
       mapping[guid_byte * 2] = '0';

--- a/known_configs.md
+++ b/known_configs.md
@@ -33,8 +33,21 @@ SDL_GAMECONTROLLERCONFIG='03000000c82d00001d30000011010000,8BitDo Ultimate 2C Wi
 ```
 
 Just the environment variable:
+
 ```sh
 SDL_GAMECONTROLLERCONFIG='03000000c82d00001d30000011010000,8BitDo Ultimate 2C Wired Controller,a:b0,b:b1,x:b3,y:b4,back:b10,guide:b12,start:b11,leftstick:b13,rightstick:b14,leftshoulder:b6,rightshoulder:b7,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,leftx:a0,lefty:a1,rightx:a2,righty:a3,lefttrigger:a5,righttrigger:a4,platform:Linux,'
 ```
 
+## Xbox Series X Controller
 
+Stream launch options:
+
+```sh
+SDL_GAMECONTROLLERCONFIG='030000005e040000120b000005050000,Xbox Series X Controller,a:b0,b:b1,x:b2,y:b3,back:b6,guide:b8,start:b7,leftstick:b9,rightstick:b10,leftshoulder:b4,rightshoulder:b5,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,misc1:b11,leftx:a0,lefty:a1,rightx:a3,righty:a4,lefttrigger:a2,righttrigger:a5,platform:Linux,' %command%
+```
+
+Just the environment variable:
+
+```sh
+SDL_GAMECONTROLLERCONFIG='030000005e040000120b000005050000,Xbox Series X Controller,a:b0,b:b1,x:b2,y:b3,back:b6,guide:b8,start:b7,leftstick:b9,rightstick:b10,leftshoulder:b4,rightshoulder:b5,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,misc1:b11,leftx:a0,lefty:a1,rightx:a3,righty:a4,lefttrigger:a2,righttrigger:a5,platform:Linux,'
+```


### PR DESCRIPTION
Adding XBOX Series X controller to the known configs. This config works on my machine :).

I ran this on my Arch machine and caught a segfault, because keyboards are apparently joysticks but not gamepads, so getting their mapping just returns NULL. So I provided a little fix for that too.